### PR TITLE
docs: add Tesla T4/Turing hardware notes (attn-impl, dtype, quantization)

### DIFF
--- a/GPA_1.5/docs/infer.md
+++ b/GPA_1.5/docs/infer.md
@@ -213,8 +213,27 @@ python GPA-v1.5/infer.py \
   --device cpu
 ```
 
-The CLI chooses the attention backend conservatively:
+If the reason you're troubleshooting is a `flash_attention_2` import error on a CUDA GPU (see the [Tesla T4 / Turing notes](#-tesla-t4--turing-sm_75-notes) below), you don't need to give up the GPU — pass `--attn-impl sdpa` instead and keep `--device cuda`.
 
-- `flash_attention_2` on CUDA when available
+By default (`--attn-impl auto`), the CLI picks:
+
+- `flash_attention_2` whenever `--device` starts with `cuda` — **regardless of GPU generation or whether the `flash-attn` package is even installed**
 - `sdpa` on MPS
 - `eager` on CPU
+
+## 🖥️ Tesla T4 / Turing (sm_75) Notes
+
+Measured on a real Tesla T4 16GB (driver 550.163.01 / CUDA 12.4, torch 2.6.0+cu124, transformers 5.13.0). These notes apply to any Turing-class GPU (T4, and similarly L4-class cards without `flash-attn` support).
+
+- **`--attn-impl auto` crashes on Turing GPUs.** `inference/model_loader.py::normalize_attn_impl` returns `flash_attention_2` for any `cuda*` device with no check of `torch.cuda.get_device_capability()` and no check that the `flash-attn` package is installed (it isn't listed in `requirements.txt`, and `pyproject.toml` only has it commented out as an optional extra). On T4 (sm_75), the Quick Start commands above fail at model-load time with:
+  ```
+  ImportError: FlashAttention2 has been toggled on, but it cannot be used due to the following error:
+  the package for FlashAttention2 doesn't seem to be installed.
+  ```
+  `flash-attn` v2 also requires sm80+ in general, so it would not help on T4 even if installed. **Fix:** explicitly pass `--attn-impl sdpa` — this is already a supported CLI value, no code change needed, and both ASR and TTS complete normally.
+
+- **There is no `--dtype` CLI flag.** `--device` and `--attn-impl` are exposed as CLI options, but dtype is hardcoded in `model_loader.py` (`torch.bfloat16` on CUDA, otherwise the model default). Changing it requires editing `load_text_stack()` directly. On T4, this hardcoded `bf16` is measurably suboptimal with SDPA: PyTorch's `EFFICIENT_ATTENTION` kernel rejects `bfloat16` inputs and silently falls back to the slower `MATH` backend, whereas `fp16` is accepted by `EFFICIENT_ATTENTION` directly. Per-token generation time was within noise between the two in our runs (bf16 ≈36.6–37.2 ms/token vs fp16 ≈34.2–39.4 ms/token), but only `fp16` reaches the faster kernel path on this GPU class.
+
+- **`bitsandbytes` int8 quantization works, but is a real trade-off, not a free win.** Passing `quantization_config=BitsAndBytesConfig(load_in_8bit=True)` to `AutoModelForCausalLM.from_pretrained` (not currently mentioned anywhere in the docs) reduces peak VRAM after load by **~43%** (2317 MB → 1327 MB bf16→int8, reproduced twice), but batch=1 autoregressive decode is **~3.2x slower** (≈36–39 ms/token bf16/fp16 → ≈121–125 ms/token int8, reproduced twice). Whether this trade is worth it depends on whether you're VRAM-constrained or latency-constrained.
+
+- **VRAM headroom on T4 is not a concern for this model.** GPA-v1.5's native infer path uses a 0.6B `ArkAsr` backbone. Full-pipeline peak VRAM (LLM + ASR/TTS + Spark tokenizer) measured ≈4.0–4.2 GB for bf16/fp16 and ≈3.0–3.1 GB for int8 — roughly 74–81% of a T4's 16GB left unused. Unlike larger models, OOM is not a practical risk here on T4-class hardware.


### PR DESCRIPTION
## Motivation

Ran the GPA-v1.5 native infer Quick Start (`GPA_1.5/docs/infer.md`) verbatim on a real Tesla T4 16GB (Turing, sm_75; driver 550.163.01 / CUDA 12.4, torch 2.6.0+cu124, transformers 5.13.0) and hit a crash the docs don't mention, plus found a couple of undocumented behaviors worth calling out for anyone on Turing-class GPUs (T4, similarly L4).

## Changes

Doc-only additions to `GPA_1.5/docs/infer.md` — no code changes:

1. **`--attn-impl auto` crashes on Turing GPUs.** `inference/model_loader.py::normalize_attn_impl` returns `flash_attention_2` for any `cuda*` device with no `torch.cuda.get_device_capability()` check and no check that `flash-attn` is even installed (it's commented out as an optional extra in `pyproject.toml`, not in `requirements.txt`). Following the Quick Start as-is on T4 fails at model load with:
   ```
   ImportError: FlashAttention2 has been toggled on, but it cannot be used due to the following error:
   the package for FlashAttention2 doesn't seem to be installed.
   ```
   Documented the fix: pass `--attn-impl sdpa` (already a supported CLI value, no code change) — both ASR and TTS complete normally. Also corrected the "Fast Troubleshooting #5" section, which previously only suggested falling back to `--device cpu`; now it points to `--attn-impl sdpa` first so users don't need to give up the GPU.

2. **No `--dtype` CLI flag.** `--device` and `--attn-impl` are exposed as CLI args, but dtype is hardcoded to `torch.bfloat16` on CUDA in `model_loader.py`. Documented that this is measurably suboptimal on T4: PyTorch's SDPA `EFFICIENT_ATTENTION` kernel rejects `bfloat16` and silently falls back to the slower `MATH` path, while `fp16` reaches `EFFICIENT_ATTENTION` directly (per-token latency was within noise in our runs, but only fp16 hits the faster kernel on this GPU class).

3. **`bitsandbytes` int8 quantization trade-off.** Not mentioned anywhere in the docs today. Measured `BitsAndBytesConfig(load_in_8bit=True)` reducing peak VRAM by ~43% (2317 MB → 1327 MB, reproduced twice) but making batch=1 autoregressive decode ~3.2x slower (≈36–39 ms/token → ≈121–125 ms/token, reproduced twice). Documented as a real trade-off rather than a free win.

4. **VRAM headroom note.** The native infer path uses a 0.6B backbone; full-pipeline peak VRAM measured ≈4.0–4.2 GB (bf16/fp16) / ≈3.0–3.1 GB (int8) — roughly 74–81% of a T4's 16GB unused. Noted this so T4/L4 users know OOM isn't a practical concern here.

## Testing

- Ran `GPA_1.5/infer.py --task asr` and `--task tts` end-to-end on a Tesla T4 16GB with `--attn-impl sdpa`: both complete successfully (ASR transcript correct, TTS produces a valid wav).
- Reproduced the `flash_attention_2` `ImportError` with the default `--attn-impl auto` on the same box (2 runs, deterministic).
- Measured peak VRAM and per-token decode time for bf16/fp16/int8 via the repo's own `AutoModelForCausalLM`/`BitsAndBytesConfig` APIs (no repo code modified), each reproduced twice.
- This PR only touches `GPA_1.5/docs/infer.md`; no source files changed.